### PR TITLE
Update Record template to use new getDecoratedLink() method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     ],
     "require": {
         "silverstripe/framework": "^5",
-        "silverstripe/silverstripe-discoverer": "^1.1"
+        "silverstripe/silverstripe-discoverer": "^1.2"
     },
     "config": {
         "allow-plugins": {

--- a/templates/SilverStripe/Discoverer/Service/Results/Record.ss
+++ b/templates/SilverStripe/Discoverer/Service/Results/Record.ss
@@ -1,6 +1,6 @@
 <li class="discoverer-result">
     <h3 class="discoverer-result__title">
-        <a href="{$Link}<% if $AnalyticsData %>?$AnalyticsData<% end_if %>"
+        <a href="{$getDecoratedLink($Link)}"
            class="discoverer-result__link"
         >$Title</a>
     </h3>


### PR DESCRIPTION
Depends on https://github.com/silverstripeltd/silverstripe-discoverer/pull/17

We'll need to wait until a new version is tagged for Discoverer and then update the minimum requirements here.