### PR TITLE
Breaking: Use new spelling suggestions feature. Update controller configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,48 @@ This search UI assumes that you have the following fields available in your inde
 * `content` (optional)
 * `body` (optional)
 
+## Spelling suggestions (aka "did you mean")
+
+**Not to be confused with Query suggestions (aka autocomplete).**
+
+Spelling suggestions for queries can be enabled with the following environment variable.
+
+```yaml
+SEARCH_SPELLING_SUGGESTIONS_ENABLED=1
+```
+
+Note: Spelling suggestions is an API query that happens **after** you have received results - so it will impact your
+page load times.
+
+The spelling suggestions feature needs to know what fields you would like it to search in. By default, it **only**
+provides suggestions based on the `title` field. You can add additional fields by updating the following configuration.
+
+```yaml
+SilverStripe\DiscovererSearchUI\Controller\SearchResultsController:
+  # Provide spelling suggestions whenever there is 5 or less search results
+  spelling_suggestion_fields:
+    - content
+    - body
+```
+
+By default, these suggestions will be provided when you have zero (`0`) search results. This default can be updated
+through the following configruation.
+
+```yaml
+SilverStripe\DiscovererSearchUI\Controller\SearchResultsController:
+  # Provide spelling suggestions whenever there is 5 or less search results
+  result_count_for_spelling_suggestions: 5
+```
+
+By default, you will receive (up to) 1 suggestion (there aren't always spelling suggestions for a given query). This
+default can be udpated through the following configuration.
+
+```yaml
+SilverStripe\DiscovererSearchUI\Controller\SearchResultsController:
+  # Provide (up to) 5 spelling suggestions
+  spelling_suggestions_limit: 5
+```
+
 ## Customisations
 
 The out of the box `SearchResultsController` comes with 3 extension points that will allow you to modify the search

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ provides suggestions based on the `title` field. You can add additional fields b
 
 ```yaml
 SilverStripe\DiscovererSearchUI\Controller\SearchResultsController:
-  # Provide spelling suggestions whenever there is 5 or less search results
   spelling_suggestion_fields:
     - content
     - body
@@ -57,7 +56,6 @@ through the following configruation.
 
 ```yaml
 SilverStripe\DiscovererSearchUI\Controller\SearchResultsController:
-  # Provide spelling suggestions whenever there is 5 or less search results
   result_count_for_spelling_suggestions: 5
 ```
 
@@ -66,7 +64,6 @@ default can be udpated through the following configuration.
 
 ```yaml
 SilverStripe\DiscovererSearchUI\Controller\SearchResultsController:
-  # Provide (up to) 5 spelling suggestions
   spelling_suggestions_limit: 5
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ SilverStripe\DiscovererSearchUI\Controller\SearchResultsController:
   spelling_suggestions_limit: 5
 ```
 
+Some services support both "raw" and "foramtted" results for spelling suggestions. Our default behaviour is to **not**
+request formatted suggestions. You can enable this in your requests through the following configuration.
+
+```yaml
+SilverStripe\DiscovererSearchUI\Controller\SearchResultsController:
+    spelling_suggestions_formatted: true
+```
+
 ## Customisations
 
 The out of the box `SearchResultsController` comes with 3 extension points that will allow you to modify the search

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     ],
     "require": {
         "silverstripe/framework": "^5",
-        "silverstripe/silverstripe-discoverer": "^1.2"
+        "silverstripe/silverstripe-discoverer": "^2"
     },
     "config": {
         "allow-plugins": {

--- a/src/Controller/SearchResultsController.php
+++ b/src/Controller/SearchResultsController.php
@@ -39,6 +39,8 @@ class SearchResultsController extends PageController
 
     private static int $spelling_suggestions_limit = 1;
 
+    private static bool $spelling_suggestions_formatted = false;
+
     private static array $spelling_suggestion_fields = [
         'title',
     ];
@@ -153,12 +155,19 @@ class SearchResultsController extends PageController
         $keywords = $request->getVar($fieldKeywords);
         // The fields that we want to query on
         $suggestionFields = $this->config()->get('spelling_suggestion_fields');
+        // Whether we want to have formatted results (if supported by our search service)
+        $suggestionsFormatted = $this->config()->get('spelling_suggestions_formatted');
 
         // The index variant that we are fetching records from (as defined under `indexes` in search.yml)
         $index = $this->config()->get('index_variant');
 
         $service = SearchService::singleton();
-        $suggestion = Suggestion::create($keywords, $this->config()->get('spelling_suggestions_limit'), $suggestionFields);
+        $suggestion = Suggestion::create(
+            $keywords,
+            $this->config()->get('spelling_suggestions_limit'),
+            $suggestionFields,
+            $suggestionsFormatted
+        );
 
         $this->invokeWithExtensions('updateSuggestionQuery', $suggestion);
 

--- a/templates/SilverStripe/Discoverer/Service/Results/Suggestions.ss
+++ b/templates/SilverStripe/Discoverer/Service/Results/Suggestions.ss
@@ -4,10 +4,10 @@
             <li class="discoverer-suggestion">
                 <a href="{$Up.TargetQueryUrl}?{$Up.TargetQueryStringField}={$Me}"
                    class="discoverer-suggestion__link"
-                >$Me</a>
+                >$Me.Raw</a>
             </li>
         <% else %>
-            <li class="discoverer-suggestion">$Me</li>
+            <li class="discoverer-suggestion">$Me.Raw</li>
         <% end_if %>
     <% end_loop %>
 </ul>

--- a/templates/SilverStripe/Discoverer/Service/Results/Suggestions.ss
+++ b/templates/SilverStripe/Discoverer/Service/Results/Suggestions.ss
@@ -2,12 +2,12 @@
     <% loop $Me %>
         <% if $Up.TargetQueryUrl && $Up.TargetQueryStringField %>
             <li class="discoverer-suggestion">
-                <a href="{$Up.TargetQueryUrl}?{$Up.TargetQueryStringField}={$Me}"
+                <a href="{$Up.TargetQueryUrl}?{$Up.TargetQueryStringField}={$Me.Raw}"
                    class="discoverer-suggestion__link"
-                >$Me.Raw</a>
+                >$Me</a>
             </li>
         <% else %>
-            <li class="discoverer-suggestion">$Me.Raw</li>
+            <li class="discoverer-suggestion">$Me</li>
         <% end_if %>
     <% end_loop %>
 </ul>

--- a/templates/SilverStripe/DiscovererSearchUI/Page/Layout/SearchResults.ss
+++ b/templates/SilverStripe/DiscovererSearchUI/Page/Layout/SearchResults.ss
@@ -3,11 +3,11 @@
         $SearchForm
     </div>
 
-    <% if $QuerySuggestions %>
+    <% if $SpellingSuggestions %>
         <div class="discoverer-suggestions">
             <h2><%t SilverStripe\DiscovererSearchUI\Page\SearchResults.SearchSuggestions 'Search suggestions' %></h2>
 
-            $QuerySuggestions
+            $SpellingSuggestions
         </div>
     <% end_if %>
 


### PR DESCRIPTION
# Breaking

This requires version 2 of Discoverer, so there are already "breaking changes" here. We are marked as an alpha though - so I think that means we can just go to `0.3.0`, and "breaking things" is still part of the contract of an alpha(?).

## Configuration and environment variables

I decided to rename our configuration and environment variable so that they are all specific to **spelling** suggestions. This way, if we decide to bring **query** suggestions back later on, we can do so without there being confusion with these names.

## Breaking changes (summary)

* [Discoverer v2](https://github.com/silverstripeltd/silverstripe-discoverer/releases/tag/2.0.0)
* Environment variable `SEARCH_SUGGESTIONS_ENABLED` has been replaced with `SEARCH_SPELLING_SUGGESTIONS_ENABLED`
  * OotB support for **Query Suggestions** has been removed
  * Retionale: We believe it is actually Spelling Suggestions that more closely fit the current use case
* Configuration `result_count_for_suggestions` has been replaced with `result_count_for_spelling_suggestions`
* Configuration `suggestions_limit ` has been replaced with `spelling_ suggestions_limit`
* `SearchResultsController::QuerySuggestions()` has been replaced with `SearchResultsController::SpellingSuggestions()`
* `SearchResultsController::ENV_SUGGESTIONS_ENABLED` has been removed
* New configuration options added for Spelling Suggestions (see README)