### PR TITLE
AOS-100: Add query sanitisation example to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,19 @@ If you need to add support for any filter fields you've added, if you'd like to 
 you'd like to change absolutely anything else about your `Query` before it is sent to your search service, then you can
 do so by implementing the `updateSearchQuery()` method.
 
+If updating templates so that the Query is shown on the page it is important to make sure it is sanitised
+to mitigate potential cross-site scripting (xss) attacks. See example below on how to update the Query.
+
 ```php
 class SearchExtension extends SearchResultsExtension
 {
 
     public function updateSearchQuery(Query $query, HTTPRequest $request): void
     {
+        // Sanitise the query string to mitigate xss
+        $keywords = $query->getQueryString();
+        $query->setQueryString(Convert::raw2xml($keywords));
+        
         // A filter called "topic" that we added to our search form
         $topic = $request->getVar('topic') ?: null;
 


### PR DESCRIPTION
# Jira ticket
[AOS-100 XSS possible on default sdk setup](https://silverstripe.atlassian.net/browse/AOS-100)

# Description
A common pattern for a search results page is to display the original query term within the results summary text.
For example, `Displaying 1 - 10 results of 20 for "health"`

So we could set this up by passing the query object into the Summary.ss template and changing it to ...

````
<p class="discoverer-results__summary"><%t SilverStripe\Discoverer\Includes\Summary.Results 'Displaying {first} - {last} results of {total} for "{query}"' first=$FirstItem last=$LastItem total=$TotalItems query=$query %></p>
````

Although this perhaps this is an implementation issue rather than a module issue, and there are alternatives for the developer to ensure output is sanitised, this would seem the most convenient way of including the search term in the template. Currently when doing this there is an XSS issue where user input is output directly to the template.

For example,
`<h1 style='color:red'>Test</h1>` as search term: 
<img width="477" height="198" alt="Screenshot 2025-08-19 at 9 01 04 AM" src="https://github.com/user-attachments/assets/ac49c8a1-d50f-4084-aa80-1bb141bec8b6" />

`<IMG height=100 width=100 onmouseover=alert('test')>` as the search term:
<img width="939" height="242" alt="Screenshot 2025-08-19 at 9 03 22 AM" src="https://github.com/user-attachments/assets/2e863ad8-3b25-4e9c-b7c9-f5e9a15e3e30" />

# Documentation changes
I've added documentation to highlight importance of sanitising the query string within the search implementation, since the Query class in discoverer assumes that it is safe to include in the template.
