### PR TITLE
AOS-100: Update docs for sanitisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,19 +111,12 @@ If you need to add support for any filter fields you've added, if you'd like to 
 you'd like to change absolutely anything else about your `Query` before it is sent to your search service, then you can
 do so by implementing the `updateSearchQuery()` method.
 
-If updating templates so that the Query is shown on the page it is important to make sure it is sanitised
-to mitigate potential cross-site scripting (xss) attacks. See example below on how to update the Query.
-
 ```php
 class SearchExtension extends SearchResultsExtension
 {
 
     public function updateSearchQuery(Query $query, HTTPRequest $request): void
     {
-        // Sanitise the query string to mitigate xss
-        $keywords = $query->getQueryString();
-        $query->setQueryString(Convert::raw2xml($keywords));
-        
         // A filter called "topic" that we added to our search form
         $topic = $request->getVar('topic') ?: null;
 
@@ -214,6 +207,58 @@ This module has provided a simple `Record.ss` template, which assumes some basic
 
 If you do not use these fields, have extra fields you'd like to add, or want to change the way the fields are display,
 then you will need to override the template found under `templates/SilverStripe/Discoverer/Service/Results/Record.ss`.
+
+### Mitigating against XSS
+When handling user input (such as a search term that might be passed in on the querystring of a link) it is important
+to consider security and to understand when and where that user input needs to be sanitised.
+
+#### Sending the query to Elastic
+Generally speaking you shouldn't need to sanitise the user search term that you pass to the `Query` class. The
+Elastic client should handle this in a safe manner and do any escaping it needs to, such as escaping quotes and
+prevent the query json being manipulated.
+
+````php
+$keywords = $request->getVar($fieldKeywords);
+
+// Instantiate a new Query, and provide the search terms that we wish to search for
+$query = Query::create($keywords);
+````
+
+Also, any sanitisation that you do at this point might mean a valid search term is escaped, leading to an incorrect
+set of search results. For example, if searching for `O'Leary` you don't want to escape html entities at this point, since
+this will results in `O&#039;Leary` being sent to elastic.
+
+#### Showing the search term in the search page input field
+
+````php
+$keywords = $this->getRequest()->getVar($fieldKeywords);
+
+$fields = FieldList::create(
+    TextField::create($fieldKeywords, _t(self::class . '.FIELD_KEYWORD_LABEL', 'Search terms'), $keywords)
+        ->setInputType('search')
+);
+````
+When configuring your search form and passing the search term to a `TextField` this won't need sanitising,
+since the templating system will handle this for you. 
+
+#### Including the query on the page
+The potential for cross site-scripting (where malicious code can be inserted into the page) can occur when outputting user
+input back to the page - for example, if you wish to modify the results template to include `Showing 1 of 10 results for "my search term"`.
+
+If your implementation requires you to include the query within the results template, one way you could do this is to
+create an extension for the `Results` class and add a custom function that can be called from the Results template.
+
+```` php
+public function sanitisedQuery(Query $query): DBText
+{
+    return DBText::create()->setValue($query->forTemplate());
+}
+````
+
+In this case, because the return type is `DBText`, the Silverstripe templating system will handle safe encoding
+of `$sanitisedQuery` for you.
+
+
 
 ## Contributing
 

--- a/src/Controller/SearchResultsController.php
+++ b/src/Controller/SearchResultsController.php
@@ -14,6 +14,7 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\TextField;
+use SilverStripe\ORM\FieldType\DBText;
 use SilverStripe\View\Requirements;
 
 class SearchResultsController extends PageController
@@ -60,8 +61,8 @@ class SearchResultsController extends PageController
         $fieldKeywords = $this->config()->get('field_keywords');
         $fieldSubmit = $this->config()->get('field_submit');
 
-        // The keyword that we want to search
-        $keywords = Convert::raw2xml($this->getRequest()->getVar($fieldKeywords));
+        // The keyword that we want to search (templating will handle escaping for the input field)
+        $keywords = $this->getRequest()->getVar($fieldKeywords);
 
         $fields = FieldList::create(
             TextField::create($fieldKeywords, _t(self::class . '.FIELD_KEYWORD_LABEL', 'Search terms'), $keywords)


### PR DESCRIPTION
# Jira ticket
[https://silverstripe.atlassian.net/browse/AOS-100](https://silverstripe.atlassian.net/browse/AOS-100)

# Discussion
I've previously added some notes around the sanitisation of the query string (search term). However, I have noted that the sanitisation suggested will escape certain characters and could prevent accurate results from being returned. (For example O'Leary where escaping of the the `'` character would occur). Looking further into this further, Elastic is not susceptible to cross-site scripting and the Elastic client should handle any escaping it needs to do (typically through json decoding of the query).

The Elastic documentation provides advice around sanitisation (see https://www.elastic.co/guide/en/app-search/current/sanitization-guide.html) and is more to do with ensuring that raw content that can be included in results is safe.

Here, I've updated the documentation and made it clearer where and when sanitisation is important. For the most part, Silverstripe includes its own santisation handling within its templating system.