### PR TITLE
AOS-358: Update decoratedLink in template

### DIFF
--- a/templates/SilverStripe/Discoverer/Service/Results/Record.ss
+++ b/templates/SilverStripe/Discoverer/Service/Results/Record.ss
@@ -1,6 +1,6 @@
 <li class="discoverer-result">
     <h3 class="discoverer-result__title">
-        <a href="{$getDecoratedLink($Link)}"
+        <a href="{$getDecoratedLink($Link.forTemplate)}"
            class="discoverer-result__link"
         >$Title</a>
     </h3>


### PR DESCRIPTION
As mentioned in this issue: https://github.com/silverstripeltd/silverstripe-discoverer/issues/35

In CMS 6 there was a change that caused template functions to no longer be converted to strings so forTemplate or similar should be added when passing to a template function.